### PR TITLE
Fix test for chsh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -32,10 +32,12 @@ sed -i -e "/export PATH=/ c\\
 export PATH=\"$PATH\"
 " ~/.zshrc
 
-if [ "$SHELL" != "$(grep /zsh$ /etc/shells | tail -1)" ]; then
+TEST_CURRENT_SHELL=$(expr "$SHELL" : '.*/\(.*\)')
+if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then
     echo "\033[0;34mTime to change your default shell to zsh!\033[0m"
     chsh -s $(grep /zsh$ /etc/shells | tail -1)
 fi
+unset TEST_CURRENT_SHELL
 
 echo "\033[0;32m"'         __                                     __   '"\033[0m"
 echo "\033[0;32m"'  ____  / /_     ____ ___  __  __   ____  _____/ /_  '"\033[0m"


### PR DESCRIPTION
In case `$SHELL` is Zsh but not the last one in `/etc/shells`, a `chsh` will still be triggered, as pointed out in [robbyrussel/oh-my-zsh#2836](https://github.com/robbyrussell/oh-my-zsh/pull/2836#discussion-diff-27356466).

This PR fixes that problem.